### PR TITLE
remove link to past session from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ In this exercise we will use a github repo to collaboratively collate and simula
 
 
 # **GO!**
-[link to full session handout](https://annakrystalli.github.io/Mozfest_github-rstudio/index.html)
 
 #### **github:** fork 
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,6 @@ In this exercise we will use a github repo to collaboratively collate and simula
 - Once all trajectories are simulated they'll be plotted together. 
 - Participants will then get to **see the skull and beak shape** corresponding to their species relative body size!
 
-<br>
-
-### **Next Session: Join Remotely!**
-## [**NHM STARS training course**](https://mozillafestival.org/): **Thursday, 18th May 11:00-12:00**
-
-We'll be **accepting pull requests** by remote participants between **11.30 - 12.00**, so anyone can get involved! Follow [**#EvoLottery**](https://twitter.com/search?f=tweets&q=EvoLottery&src=typd) on the day for live updates on twitter.
-
-***
 
 <br>
 


### PR DESCRIPTION
This removes the link to the session from 2016 from the readme, resolves #570 

Most of the other bits in the readme relate to what I assume is the initial incarnation of this exercise, using RStudio.
I haven't encountered any issues with trainees accidentally using these instructions and all the links still seem to work, so I think leaving them is fine. Do you agree?