### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: main
+          ref: master
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
The original workflow file refers to the `main` branch, instead of `master` which is the correct default for this repo. This fixes that.

I'd also suggest that with this action implemented we switch the Pages settings from `Deploy from a Branch` to `Github Actions`, currently it seems to be re-running the "deploy from branch" action every time `master` has changed (i.e. on every merged PR), even though the html file hasn't changed. Seems like a bit of a waste.